### PR TITLE
chore<k8s>: Add basic Kubernetes API client support to criu-coordinator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,12 @@ bytes = "1.4.0"
 prost = "0.11.8"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 config = "0.13.1"
+reqwest = { version = "0.12.14", features = ["rustls-tls"] }
+
+# K8s client lib
+kube = "0.99.0"
+k8s-openapi = { version = "0.24.0", features = ["v1_32"] }
+tokio = { version = "1.44.1", features = ["full"] }
 
 [build-dependencies]
 prost-build = "0.11.8"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,16 +49,32 @@ pub enum Mode {
         #[clap(short, long, help = "A colon-separated list of dependency IDs")]
         deps: String,
 
-        #[clap(short, long, default_value = "pre-dump", help = "Action name indicating the stage of checkpoint/restore")]
+        #[clap(
+            short,
+            long,
+            default_value = "pre-dump",
+            help = "Action name indicating the stage of checkpoint/restore"
+        )]
         action: String,
 
-        #[clap(short = 'D', long, default_value = ".", help = "Images directory where the stream socket is created")]
+        #[clap(
+            short = 'D',
+            long,
+            default_value = ".",
+            help = "Images directory where the stream socket is created"
+        )]
         images_dir: String,
 
         #[clap(short = 's', long, help = "Use checkpoint streaming")]
         stream: bool,
 
-        #[clap(short = 'o', long, default_value = "-", hide_default_value = true, help = "Log file name")]
+        #[clap(
+            short = 'o',
+            long,
+            default_value = "-",
+            hide_default_value = true,
+            help = "Log file name"
+        )]
         log_file: String,
     },
 
@@ -70,7 +86,70 @@ pub enum Mode {
         #[clap(short, long, default_value = DEFAULT_PORT, help = "Port to bind the server to")]
         port: u16,
 
-        #[clap(short = 'o', long, default_value = "-", hide_default_value = true, help = "Log file name")]
+        #[clap(
+            short = 'o',
+            long,
+            default_value = "-",
+            hide_default_value = true,
+            help = "Log file name"
+        )]
         log_file: String,
+    },
+
+    #[clap(about = "Kubernetes operations", aliases = ["k8s"])]
+    Kubernetes {
+        #[clap(subcommand)]
+        command: KubernetesCommand,
+    },
+}
+
+#[derive(Parser)]
+pub enum KubernetesCommand {
+    #[clap(about = "Discover pods and containers")]
+    Discover {
+        #[clap(short, long, default_value = "default", help = "Kubernetes namespace")]
+        namespace: String,
+
+        #[clap(short, long, help = "Label selector to filter pods")]
+        selector: Option<String>,
+    },
+
+    #[clap(about = "Trigger chankpoint for containers")]
+    Checkpoint {
+        #[clap(short, long, default_value = "default", help = "Kubernetes namespace")]
+        namespace: String,
+
+        #[clap(short, long, help = "Pod name")]
+        pod: String,
+
+        #[clap(short, long, help = "Container name")]
+        container: String,
+
+        #[clap(short, long, help = "Node name")]
+        node: String,
+
+        #[clap(long, help = "Path to client certificate for kubelet authentication")]
+        cert_path: Option<String>,
+
+        #[clap(long, help = "Path to client key for kubelet authentication")]
+        key_path: Option<String>,
+    },
+
+    #[clap(about = "Coordinated checkpoint for multiple containers")]
+    CoordinatedCheckpoint {
+        #[clap(short, long, default_value = "default", help = "Kubernetes namespace")]
+        namespace: String,
+
+        #[clap(short, long, help = "Label selector to identify application pods")]
+        selector: String,
+
+        #[clap(long, help = "Path to dependencies file (JSON format)")]
+        deps_file: Option<String>,
+
+        #[clap(long, help = "Path to client certificate for authentication")]
+        cert: Option<String>,
+
+        #[clap(long, help = "Path to client key for authentication")]
+        key: Option<String>,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,7 +116,12 @@ pub enum KubernetesCommand {
 
     #[clap(about = "Trigger chankpoint for containers")]
     Checkpoint {
-        #[clap(short, long, default_value = "default", help = "Kubernetes namespace")]
+        #[clap(
+            short = 'n',
+            long,
+            default_value = "default",
+            help = "Kubernetes namespace"
+        )]
         namespace: String,
 
         #[clap(short, long, help = "Pod name")]
@@ -125,7 +130,7 @@ pub enum KubernetesCommand {
         #[clap(short, long, help = "Container name")]
         container: String,
 
-        #[clap(short, long, help = "Node name")]
+        #[clap(short = 'N', long, help = "Node name")]
         node: String,
 
         #[clap(long, help = "Path to client certificate for kubelet authentication")]
@@ -139,6 +144,9 @@ pub enum KubernetesCommand {
     CoordinatedCheckpoint {
         #[clap(short, long, default_value = "default", help = "Kubernetes namespace")]
         namespace: String,
+
+        #[clap(short, long, help = "Application name (used for labeling)")]
+        app_name: String,
 
         #[clap(short, long, help = "Label selector to identify application pods")]
         selector: String,

--- a/src/k8s/checkpoint.rs
+++ b/src/k8s/checkpoint.rs
@@ -1,0 +1,35 @@
+use k8s_openapi::api::core::v1::Pod;
+use kube::{
+    api::{Api, ListParams},
+    Client, Config,
+};
+use log::*;
+use std::{convert::TryFrom, error::Error};
+
+pub struct K8sClient {
+    client: Client,
+}
+
+impl K8sClient {
+    // create a new client
+    pub async fn new() -> Result<Self, Box<dyn Error>> {
+        let config = Config::infer().await?;
+        let client = Client::try_from(config)?;
+        // Can use Client::new()
+        Ok(Self { client })
+    }
+
+    // Get kube-client
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
+    // List pods in namespace
+    pub async fn list_pods(&self, namespace: &str) -> Result<Vec<Pod>, Box<dyn Error>> {
+        let api: Api<Pod> = Api::namespaced(self.client.clone(), namespace);
+        let pods = api.list(&ListParams::default()).await?;
+
+        info!("Found {} pods in namespace {}", pods.items.len(), namespace);
+        Ok(pods.items)
+    }
+}

--- a/src/k8s/checkpoint.rs
+++ b/src/k8s/checkpoint.rs
@@ -1,35 +1,78 @@
-use k8s_openapi::api::core::v1::Pod;
-use kube::{
-    api::{Api, ListParams},
-    Client, Config,
-};
+use super::discovery::DiscoveredContainer;
 use log::*;
-use std::{convert::TryFrom, error::Error};
+use reqwest::{Client as HttpClient, StatusCode};
+use std::{error::Error, time::Duration};
 
-pub struct K8sClient {
-    client: Client,
+// Trigger checkpoint for a container using the kubelet API
+pub async fn trigger_checkpoint(
+    container: &DiscoveredContainer,
+    node_address: &str,
+    cert_path: Option<&str>,
+    key_path: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    let kubelet_port = 10250;
+    let url = format!(
+        "https://{}:{}/checkpoint/{}/{}/{}",
+        node_address,
+        kubelet_port,
+        container.namespace,
+        container.pod_name,
+        container.container_name
+    );
+
+    info!("Triggering checkpoint via kubelet API: {}", url);
+
+    let client_builder = HttpClient::builder()
+        .timeout(Duration::from_secs(30))
+        .danger_accept_invalid_certs(true);
+
+    let client = if let (Some(cert), Some(key)) = (cert_path, key_path) {
+        // load client certificate and key for the kubelet authentication
+        let cert = std::fs::read(cert)?;
+        let key = std::fs::read(key)?;
+        let identity = reqwest::Identity::from_pem(&[cert, key].concat())?;
+        client_builder.identity(identity).build()?
+    } else {
+        client_builder.build()?
+    };
+
+    let response = client.post(&url).send().await?;
+
+    match response.status() {
+        StatusCode::OK | StatusCode::CREATED | StatusCode::ACCEPTED => {
+            info!(
+                "Checkpoint successfully triggered for {}/{}/{}",
+                container.namespace, container.pod_name, container.container_name
+            );
+            Ok(())
+        }
+        status => {
+            let error_msg = format!(
+                "Failed to trigger checkpoint: HTTP {} - {}",
+                status,
+                response.text().await?
+            );
+            error!("{}", error_msg);
+            Err(error_msg.into())
+        }
+    }
 }
 
-impl K8sClient {
-    // create a new client
-    pub async fn new() -> Result<Self, Box<dyn Error>> {
-        let config = Config::infer().await?;
-        let client = Client::try_from(config)?;
-        // Can use Client::new()
-        Ok(Self { client })
-    }
+// Gets the status of a checkpoint
+pub async fn get_checkpoint_status(
+    container: &DiscoveredContainer,
+    node_address: &str,
+) -> Result<String, Box<dyn Error>> {
+    // This is a placeholder since the kubelet API doesn't expose
+    // a direct endpoint for checking checkpoint status.
+    // In a real implementation, we would check for the presence of
+    // the checkpoint file in the node's filesystem.
 
-    // Get kube-client
-    pub fn client(&self) -> &Client {
-        &self.client
-    }
+    // For now, return a mock status
+    info!(
+        "Checking checkpoint status for {}/{}/{}",
+        container.namespace, container.pod_name, container.container_name
+    );
 
-    // List pods in namespace
-    pub async fn list_pods(&self, namespace: &str) -> Result<Vec<Pod>, Box<dyn Error>> {
-        let api: Api<Pod> = Api::namespaced(self.client.clone(), namespace);
-        let pods = api.list(&ListParams::default()).await?;
-
-        info!("Found {} pods in namespace {}", pods.items.len(), namespace);
-        Ok(pods.items)
-    }
+    Ok("unknown".to_string())
 }

--- a/src/k8s/client.rs
+++ b/src/k8s/client.rs
@@ -1,0 +1,34 @@
+use k8s_openapi::api::core::v1::Pod;
+use kube::{
+    api::{Api, ListParams},
+    Client, Config,
+};
+use log::*;
+use std::{convert::TryFrom, error::Error};
+
+pub struct K8sClient {
+    client: Client,
+}
+
+impl K8sClient {
+    /// Creates a new Kubernetes client
+    pub async fn new() -> Result<Self, Box<dyn Error>> {
+        let config = Config::infer().await?;
+        let client = Client::try_from(config)?;
+        Ok(Self { client })
+    }
+
+    /// Get the underlying kube client
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
+    /// Lists pods in a namespace
+    pub async fn list_pods(&self, namespace: &str) -> Result<Vec<Pod>, Box<dyn Error>> {
+        let api: Api<Pod> = Api::namespaced(self.client.clone(), namespace);
+        let pods = api.list(&ListParams::default()).await?;
+
+        info!("Found {} pods in namespace {}", pods.items.len(), namespace);
+        Ok(pods.items)
+    }
+}

--- a/src/k8s/coordinator.rs
+++ b/src/k8s/coordinator.rs
@@ -1,0 +1,141 @@
+use crate::k8s::{
+    discover_containers, get_checkpoint_status, trigger_checkpoint, DiscoveredContainer, K8sClient,
+};
+use log::*;
+use std::{collections::HashMap, error::Error, time::Duration};
+use tokio::time;
+
+/// Represents a distributed application in Kubernetes
+pub struct DistributedApp {
+    pub name: String,
+    pub containers: Vec<DiscoveredContainer>,
+    pub dependencies: HashMap<String, Vec<String>>,
+}
+
+impl DistributedApp {
+    /// Creates a new distributed application representation
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            containers: Vec::new(),
+            dependencies: HashMap::new(),
+        }
+    }
+
+    /// Adds a container to the application
+    pub fn add_container(&mut self, container: DiscoveredContainer) {
+        self.containers.push(container);
+    }
+
+    /// Sets up dependencies between containers
+    pub fn set_dependencies(&mut self, deps: HashMap<String, Vec<String>>) {
+        self.dependencies = deps;
+    }
+}
+
+/// Coordinates checkpoint operations across a distributed application
+pub async fn coordinate_checkpoint(
+    app: &DistributedApp,
+    cert_path: Option<&str>,
+    key_path: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    info!(
+        "Starting coordinated checkpoint for application: {}",
+        app.name
+    );
+
+    // 1. Check that all containers are discoverable
+    for container in &app.containers {
+        info!(
+            "Validating container: {}/{}/{}",
+            container.namespace, container.pod_name, container.container_name
+        );
+    }
+
+    // 2. Build dependency graph (simple implementation)
+    let mut checkpoint_order = Vec::new();
+    let mut visited = HashMap::new();
+
+    // Helper function to build dependency order
+    fn visit(
+        container_id: &str,
+        deps: &HashMap<String, Vec<String>>,
+        visited: &mut HashMap<String, bool>,
+        order: &mut Vec<String>,
+    ) {
+        if visited.contains_key(container_id) {
+            return;
+        }
+
+        visited.insert(container_id.to_string(), true);
+
+        if let Some(dependencies) = deps.get(container_id) {
+            for dep in dependencies {
+                visit(dep, deps, visited, order);
+            }
+        }
+
+        order.push(container_id.to_string());
+    }
+
+    // Visit each container to build the checkpoint order
+    for container in &app.containers {
+        let container_id = format!("{}/{}", container.pod_name, container.container_name);
+        visit(
+            &container_id,
+            &app.dependencies,
+            &mut visited,
+            &mut checkpoint_order,
+        );
+    }
+
+    // 3. Trigger checkpoints in proper order
+    info!("Checkpoint order: {:?}", checkpoint_order);
+
+    for container_id in checkpoint_order {
+        // Find the container details
+        let container = app
+            .containers
+            .iter()
+            .find(|c| format!("{}/{}", c.pod_name, c.container_name) == container_id)
+            .ok_or_else(|| format!("Container not found: {}", container_id))?;
+
+        info!("Triggering checkpoint for: {}", container_id);
+
+        // Trigger the checkpoint
+        trigger_checkpoint(container, &container.node_name, cert_path, key_path).await?;
+
+        // Wait for checkpoint to complete (simple polling implementation)
+        let max_retries = 10;
+        let mut status = "unknown".to_string();
+
+        for i in 0..max_retries {
+            status = get_checkpoint_status(container, &container.node_name).await?;
+            if status == "completed" {
+                break;
+            }
+
+            info!(
+                "Checkpoint status for {}: {} (attempt {}/{})",
+                container_id,
+                status,
+                i + 1,
+                max_retries
+            );
+
+            time::sleep(Duration::from_secs(2)).await;
+        }
+
+        if status != "completed" {
+            return Err(format!("Checkpoint failed or timed out for: {}", container_id).into());
+        }
+
+        info!("Checkpoint completed for: {}", container_id);
+    }
+
+    info!(
+        "Coordinated checkpoint completed successfully for application: {}",
+        app.name
+    );
+    Ok(())
+}

--- a/src/k8s/discovery.rs
+++ b/src/k8s/discovery.rs
@@ -1,0 +1,85 @@
+use super::checkpoint::K8sClient;
+use k8s_openapi::api::core::v1::Pod;
+use kube::{core::labels, ResourceExt};
+use log::info;
+use std::error::Error;
+
+pub struct DiscoveredContainers {
+    pub pod_name: String,
+    pub namespace: String,
+    pub container_name: String,
+    pub node_name: String,
+}
+
+// Discover pods in namespace
+pub async fn dicover_pods(client: &K8sClient, namespace: &str) -> Result<Vec<Pod>, Box<dyn Error>> {
+    client.list_pods(namespace).await
+}
+
+// Discovers containers in namespace, optionally filtering it by labels selectors
+pub async fn discover_containers(
+    client: &K8sClient,
+    namespace: &str,
+    label_selector: Option<&str>,
+) -> Result<Vec<DiscoveredContainers>, Box<dyn Error>> {
+    let pods = client.list_pods(namespace).await?;
+
+    let mut containers: Vec<DiscoveredContainers> = Vec::new();
+    for pod in pods {
+        let pod_name = pod.metadata.name.clone().unwrap_or_default();
+        let pod_namespace = pod.metadata.namespace.clone().unwrap_or_default();
+        let node_name = pod
+            .spec
+            .as_ref()
+            .and_then(|ps| ps.node_name.clone())
+            .unwrap_or_default();
+
+        // Apply label selector if provided
+        if let Some(selector) = label_selector {
+            if !matches_labels(&pod, selector) {
+                continue;
+            }
+        }
+
+        // Extract container info
+        if let Some(spec) = pod.spec {
+            for container in spec.containers {
+                let container_name = container.name;
+                containers.push(DiscoveredContainers {
+                    pod_name: pod_name.clone(),
+                    namespace: pod_namespace.clone(),
+                    container_name,
+                    node_name: node_name.clone(),
+                });
+            }
+        }
+    }
+
+    info!(
+        "Discovered {} containers in namespace {}",
+        containers.len(),
+        namespace
+    );
+    Ok(containers)
+}
+
+// Check if a pod matches the given label selector
+fn matches_labels(pod: &Pod, selector: &str) -> bool {
+    // Implementing very simple logic: Can be modified for more complex selectors
+    if let Some(labels) = pod.metadata.labels.as_ref() {
+        let pairs: Vec<&str> = selector.split(",").collect();
+        for pair in pairs {
+            let kv: Vec<&str> = pair.split('=').collect();
+            if kv.len() == 2 {
+                let key = kv[0];
+                let value = kv[1];
+                if !labels.contains_key(key) || labels[key] != value {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    return false;
+}

--- a/src/k8s/mod.rs
+++ b/src/k8s/mod.rs
@@ -1,0 +1,7 @@
+mod checkpoint;
+mod client;
+mod discovery;
+
+pub use checkpoint::{get_checkpoint_status, trigger_checkpoint};
+pub use client::K8sClient;
+pub use discovery::{discover_containers, discover_pods, DiscoveredContainer};

--- a/src/k8s/mod.rs
+++ b/src/k8s/mod.rs
@@ -1,7 +1,9 @@
 mod checkpoint;
 mod client;
+mod coordinator;
 mod discovery;
 
 pub use checkpoint::{get_checkpoint_status, trigger_checkpoint};
 pub use client::K8sClient;
+pub use coordinator::{coordinate_checkpoint, DistributedApp};
 pub use discovery::{discover_containers, discover_pods, DiscoveredContainer};

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,23 +19,25 @@
 
 mod cli;
 mod client;
-mod server;
 mod constants;
-mod pipeline;
+mod k8s;
 mod logger;
+mod pipeline;
+mod server;
 
-use constants::*;
 use config::Config;
+use constants::*;
 use std::collections::HashMap;
-use std::{env, path::PathBuf, process::exit, fs, os::unix::prelude::FileTypeExt};
 use std::path::Path;
+use std::{env, fs, os::unix::prelude::FileTypeExt, path::PathBuf, process::exit};
 
 use clap::Parser;
 
-use cli::{Opts, Mode, DEFAULT_ADDRESS, DEFAULT_PORT};
+use cli::{KubernetesCommand, Mode, Opts, DEFAULT_ADDRESS, DEFAULT_PORT};
 use client::run_client;
-use server::run_server;
+use k8s::{discover_containers, trigger_checkpoint, DiscoveredContainer, K8sClient};
 use logger::init_logger;
+use server::run_server;
 
 struct ClientConfig {
     log_file: String,
@@ -65,8 +67,13 @@ fn load_config_file<P: AsRef<Path>>(images_dir: P) -> ClientConfig {
         }
     }
 
-    let settings = Config::builder().add_source(config::File::from(config_file)).build().unwrap();
-    let settings_map = settings.try_deserialize::<HashMap<String, String>>().unwrap();
+    let settings = Config::builder()
+        .add_source(config::File::from(config_file))
+        .build()
+        .unwrap();
+    let settings_map = settings
+        .try_deserialize::<HashMap<String, String>>()
+        .unwrap();
 
     if !settings_map.contains_key(CONFIG_KEY_ID) {
         panic!("id missing in config file")
@@ -102,11 +109,83 @@ fn load_config_file<P: AsRef<Path>>(images_dir: P) -> ClientConfig {
     }
 }
 
-fn main() {
-    if let Ok(action) = env::var(ENV_ACTION) {
+async fn run_kubernetes_command(command: KubernetesCommand) {
+    // Initialize K8s Client
+    let client = match K8sClient::new().await {
+        Ok(k8s_client) => k8s_client,
+        Err(e) => {
+            // error!(W"Failed to create Kubernetes client: {}", e);
+            exit(1);
+        }
+    };
 
-        let images_dir = PathBuf::from(env::var(ENV_IMAGE_DIR)
-            .unwrap_or_else(|_| panic!("Missing {} environment variable", ENV_IMAGE_DIR)));
+    match command {
+        KubernetesCommand::Discover {
+            namespace,
+            selector,
+        } => {
+            let containers =
+                match discover_containers(&client, &namespace, selector.as_deref()).await {
+                    Ok(containers) => containers,
+                    Err(e) => {
+                        // error!(W"Failed to discover containers: {}", e);
+                        exit(1);
+                    }
+                };
+            println!("Discovered {} containers:", containers.len());
+            for container in containers {
+                println!(
+                    "- Pod: {}, Container: {}, Node: {}",
+                    container.pod_name, container.container_name, container.node_name
+                );
+            }
+        }
+
+        KubernetesCommand::Checkpoint {
+            namespace,
+            pod,
+            container,
+            node,
+            cert_path,
+            key_path,
+        } => {
+            let container_info = DiscoveredContainer {
+                pod_name: pod,
+                container_name: container,
+                node_name: node.clone(),
+                namespace,
+            };
+
+            trigger_checkpoint(
+                &container_info,
+                &node,
+                cert_path.as_deref(),
+                key_path.as_deref(),
+            )
+            .await;
+
+            println!("Checkpoint triggered successfully");
+        }
+
+        KubernetesCommand::CoordinatedCheckpoint {
+            namespace,
+            selector,
+            deps_file,
+            cert,
+            key,
+        } => {
+            todo!("Need to implement")
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    if let Ok(action) = env::var(ENV_ACTION) {
+        let images_dir = PathBuf::from(
+            env::var(ENV_IMAGE_DIR)
+                .unwrap_or_else(|_| panic!("Missing {} environment variable", ENV_IMAGE_DIR)),
+        );
 
         let client_config = load_config_file(&images_dir);
 
@@ -117,17 +196,20 @@ fn main() {
                 match fs::symlink_metadata(images_dir.join(IMG_STREAMER_CAPTURE_SOCKET_NAME)) {
                     Ok(metadata) => {
                         if !metadata.file_type().is_socket() {
-                            panic!("{} exists but is not a Unix socket", IMG_STREAMER_CAPTURE_SOCKET_NAME);
+                            panic!(
+                                "{} exists but is not a Unix socket",
+                                IMG_STREAMER_CAPTURE_SOCKET_NAME
+                            );
                         }
                         // If the stream socket exists, ignore CRIU's "pre-dump" action hook.
                         exit(0);
-                    },
-                    Err(_) => false
+                    }
+                    Err(_) => false,
                 }
-            },
+            }
             ACTION_POST_DUMP => false,
             ACTION_PRE_RESTORE => false,
-            _ => exit(0)
+            _ => exit(0),
         };
 
         init_logger(Some(&images_dir), client_config.log_file);
@@ -139,7 +221,7 @@ fn main() {
             &client_config.dependencies,
             &action,
             &images_dir,
-            enable_streaming
+            enable_streaming,
         );
         exit(0);
     }
@@ -147,13 +229,37 @@ fn main() {
     let opts = Opts::parse();
 
     match opts.mode {
-        Mode::Client { address, port, id, deps, action, images_dir, stream, log_file} => {
+        Mode::Client {
+            address,
+            port,
+            id,
+            deps,
+            action,
+            images_dir,
+            stream,
+            log_file,
+        } => {
             init_logger(Some(&PathBuf::from(&images_dir)), log_file);
-            run_client(&address, port, &id, &deps, &action, &PathBuf::from(images_dir), stream);
-        },
-        Mode::Server { address, port , log_file} => {
+            run_client(
+                &address,
+                port,
+                &id,
+                &deps,
+                &action,
+                &PathBuf::from(images_dir),
+                stream,
+            );
+        }
+        Mode::Server {
+            address,
+            port,
+            log_file,
+        } => {
             init_logger(None, log_file);
             run_server(&address, port);
+        }
+        Mode::Kubernetes { command } => {
+            run_kubernetes_command(command).await;
         }
     };
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,11 @@
+# Variables #
+PROJECT_NAME := criu-coordinator
+BIN_PATH := ../target/debug/$(PROJECT_NAME)
+TEST_NAMESPACE := default
+MINIKUBE_IP := $(shell minikube ip)
+CERT_PATH := ~/.minikube/profiles/minikube/client.crt
+KEY_PATH := ~/.minikube/profiles/minikube/client.key
+
 all: loop-1 loop-2 loop-3
 
 loop-1:
@@ -10,3 +18,58 @@ loop-3:
 clean:
 	rm -f loop-1 loop-2 loop-3
 .PHONY: clean
+
+test-k8s: deploy test-discovery
+
+# DEPLOYMENT #
+deploy:
+	@echo "Deploying test pods..."
+	-kubectl delete -f ./k8s/test-pod.yml 2>/dev/null || true
+	kubectl apply -f ./k8s/test-pod.yml --validate=false
+	@echo "Waiting for pods to be ready..."
+	kubectl wait --for=condition=Ready pod/checkpoint-test-pod --timeout=60s
+	kubectl wait --for=condition=Ready pod/checkpoint-test-db --timeout=60s
+	@echo "Test pods deployed successfully."
+
+# TEST #
+# Test discovery functionality
+test-discovery:
+	@echo "Testing pod discovery..."
+	$(BIN_PATH) kubernetes discover --namespace $(TEST_NAMESPACE) --selector app=checkpoint-test
+
+# Test checkpoint functionality on a single container
+test-checkpoint:
+	@echo "Testing checkpoint functionality..."
+	@echo "cert_path: $(CERT_PATH)"
+	@echo "key_path: $(KEY_PATH)"
+	@NODE_NAME=$$(kubectl get pod checkpoint-test-pod -o jsonpath='{.spec.nodeName}'); \
+	echo "Pod is running on node: $$NODE_NAME"; \
+	$(BIN_PATH) kubernetes checkpoint \
+		--namespace $(TEST_NAMESPACE) \
+		--pod checkpoint-test-pod \
+		--container nginx \
+		--node $$NODE_NAME \
+		--cert-path $(CERT_PATH) \
+		--key-path $(KEY_PATH)
+	@echo "Checking for checkpoint files..."
+	@kubectl get pods -o wide | grep checkpoint-test-pod
+	@minikube ssh "ls -la /var/lib/kubelet/checkpoints/ | grep checkpoint-test-pod || echo 'No checkpoint found'"
+
+# Test coordinated checkpoint functionality
+test-coordinated-checkpoint:
+	@echo "Testing coordinated checkpoint..."
+	$(BIN_PATH) kubernetes coordinatedcheckpoint \
+		--namespace $(TEST_NAMESPACE) \
+		--app-name checkpoint-test \
+		--selector app=checkpoint-test \
+		--deps-file dependencies.json \
+		--cert $(CERT_PATH) \
+		--key $(KEY_PATH)
+	@echo "Checking for checkpoint files..."
+	@minikube ssh "ls -la /var/lib/kubelet/checkpoints/ | grep checkpoint-test || echo 'No checkpoint found'"
+
+# CLEANUP #
+cleanup:
+	@echo "Cleaning up test resources..."
+	-kubectl delete -f ./k8s/test-pod.yml
+	@echo "Test resources cleaned up."

--- a/tests/k8s/dependencies.json
+++ b/tests/k8s/dependencies.json
@@ -1,0 +1,5 @@
+{
+    "checkpoint-test-pod/nginx": [
+        "checkpoint-test-db/redis"
+    ]
+}

--- a/tests/k8s/minikube.sh
+++ b/tests/k8s/minikube.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+# Colors for better output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Setting up Minikube with CRIU checkpoint support...${NC}"
+
+# Check if minikube is already running
+if minikube status &>/dev/null; then
+    echo -e "${YELLOW}Stopping existing Minikube cluster...${NC}"
+    minikube stop
+fi
+
+# Start Minikube with required feature gates
+echo -e "${YELLOW}Starting Minikube with ContainerCheckpoint feature gate...${NC}"
+minikube start \
+    --container-runtime=cri-o \
+    --feature-gates="ContainerCheckpoint=true" \
+    --extra-config=kubelet.feature-gates="ContainerCheckpoint=true"
+
+# Ensure CRI-O is set up with CRIU support
+echo -e "${YELLOW}Configuring CRI-O for CRIU support...${NC}"
+minikube ssh "sudo sed -i 's/.*enable_criu_support.*/enable_criu_support = true/' /etc/crio/crio.conf || echo 'enable_criu_support = true' | sudo tee -a /etc/crio/crio.conf"
+minikube ssh "sudo systemctl restart crio"
+
+# Verify CRIU is installed
+echo -e "${YELLOW}Checking if CRIU is installed...${NC}"
+if minikube ssh "which criu" &>/dev/null; then
+    echo -e "${GREEN}CRIU is already installed.${NC}"
+else
+    echo -e "${YELLOW}Installing CRIU...${NC}"
+    minikube ssh "sudo dnf install -y criu || sudo apt-get update && sudo apt-get install -y criu"
+fi
+
+# Create directory for checkpoints if it doesn't exist
+echo -e "${YELLOW}Creating checkpoint directory...${NC}"
+minikube ssh "sudo mkdir -p /var/lib/kubelet/checkpoints"
+
+# Show certificate paths for reference
+echo -e "${YELLOW}Certificate paths for kubelet API:${NC}"
+CERT_PATH=$(minikube ssh "find /var/lib/minikube/certs -name 'client.crt' | head -1")
+KEY_PATH=$(minikube ssh "find /var/lib/minikube/certs -name 'client.key' | head -1")
+echo -e "${GREEN}Certificate path: ${CERT_PATH}${NC}"
+echo -e "${GREEN}Key path: ${KEY_PATH}${NC}"
+
+# Print a success message
+echo -e "${GREEN}Minikube setup completed successfully!${NC}"
+echo -e "${GREEN}Use these paths in your checkpoint commands:${NC}"
+echo -e "  --cert ${CERT_PATH}"
+echo -e "  --key ${KEY_PATH}"
+echo -e "${YELLOW}Now you can run 'make deploy' to deploy the test pods.${NC}"

--- a/tests/k8s/test-pod.yml
+++ b/tests/k8s/test-pod.yml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: checkpoint-test-pod
+  labels:
+    app: checkpoint-test
+    component: web
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+      ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: checkpoint-test-db
+  labels:
+    app: checkpoint-test
+    component: db
+spec:
+  containers:
+    - name: redis
+      image: redis:latest
+      ports:
+        - containerPort: 6379


### PR DESCRIPTION
## Description
This PR adds initial support for Kubernetes checkpointing API integration to criu-coordinator, enabling the tool to work with Kubernetes environments. The implementation adds a dedicated Kubernetes module that handles API interactions and provides CLI commands for discovering and checkpointing containers running in Kubernetes.

## Changes
- Added a new `kubernetes` module for API client functionality
- Implemented container discovery in Kubernetes clusters
- Added support for triggering checkpoints via kubelet API
- Updated CLI with Kubernetes-specific commands
- Integrated with existing coordinator functionality

This is the foundation for coordinating checkpoints across distributed applications running in Kubernetes.