### PR TITLE
Add global configuration file support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -24,11 +24,103 @@ use std::process::exit;
 use std::str;
 use json::object;
 use log::*;
+use config::Config;
 
 use crate::constants::MESSAGE_ACK;
 use crate::pipeline::streamer::streamer;
+use std::{collections::HashMap, path::PathBuf};
+use crate::cli::{DEFAULT_ADDRESS, DEFAULT_PORT};
+use crate::constants::*;
 
 const BUFFER_SIZE: usize = 32768 * 4;
+
+
+pub struct ClientConfig {
+    log_file: String,
+    address: String,
+    port: String,
+    id: String,
+    dependencies: String,
+}
+
+impl ClientConfig {
+    pub fn get_log_file(&self) -> &str {
+        &self.log_file
+    }
+
+    pub fn get_address(&self) -> &str {
+        &self.address
+    }
+
+    pub fn get_port(&self) -> &str {
+        &self.port
+    }
+
+    pub fn get_id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn get_dependencies(&self) -> &str {
+        &self.dependencies
+    }
+}
+
+const CONFIG_KEY_ID: &str = "id";
+const CONFIG_KEY_DEPS: &str = "dependencies";
+const CONFIG_KEY_ADDR: &str = "address";
+const CONFIG_KEY_PORT: &str = "port";
+const CONFIG_KEY_LOG: &str = "log-file";
+
+pub fn load_config_file<P: AsRef<Path>>(images_dir: P) -> ClientConfig {
+    let images_dir = images_dir.as_ref();
+    let mut config_file = images_dir.join(Path::new(CONFIG_FILE));
+    if !config_file.is_file() {
+        // The following allows us to load global config files from /etc/criu.
+        // This is useful for example when we want to use the same config file
+        // for multiple containers.
+        let config_dir = PathBuf::from("/etc/criu");
+        config_file = config_dir.join(Path::new(CONFIG_FILE));
+        if !config_file.is_file() {
+            panic!("config file does not exist")
+        }
+    }
+
+    let settings = Config::builder().add_source(config::File::from(config_file)).build().unwrap();
+    let settings_map = settings.try_deserialize::<HashMap<String, String>>().unwrap();
+
+    if !settings_map.contains_key(CONFIG_KEY_ID) {
+        panic!("id missing in config file")
+    }
+    let id = settings_map.get(CONFIG_KEY_ID).unwrap();
+
+    let mut dependencies = String::new();
+    if settings_map.contains_key(CONFIG_KEY_DEPS) {
+        dependencies = settings_map.get(CONFIG_KEY_DEPS).unwrap().to_string();
+    }
+
+    let mut address = DEFAULT_ADDRESS;
+    if settings_map.contains_key(CONFIG_KEY_ADDR) {
+        address = settings_map.get(CONFIG_KEY_ADDR).unwrap();
+    }
+
+    let mut port = DEFAULT_PORT;
+    if settings_map.contains_key(CONFIG_KEY_PORT) {
+        port = settings_map.get(CONFIG_KEY_PORT).unwrap();
+    }
+
+    let mut log_file = "-";
+    if settings_map.contains_key(CONFIG_KEY_LOG) {
+        log_file = settings_map.get(CONFIG_KEY_LOG).unwrap();
+    }
+
+    ClientConfig {
+        log_file: log_file.to_string(),
+        address: address.to_string(),
+        port: port.to_string(),
+        id: id.to_string(),
+        dependencies,
+    }
+}
 
 pub fn run_client(address: &str, port: u16, id: &str, deps: &str, action: &str, images_dir: &Path, enable_streaming: bool) {
     let server_address = format!("{address}:{port}");

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,16 +21,16 @@ use std::io::{Read, Write};
 use std::net::{TcpStream, Shutdown};
 use std::path::Path;
 use std::process::exit;
-use std::str;
+use std::{fs, str};
 use json::object;
 use log::*;
-use config::Config;
 
-use crate::constants::MESSAGE_ACK;
-use crate::pipeline::streamer::streamer;
-use std::{collections::HashMap, path::PathBuf};
 use crate::cli::{DEFAULT_ADDRESS, DEFAULT_PORT};
 use crate::constants::*;
+use crate::pipeline::streamer::streamer;
+use std::{collections::HashMap, env, path::PathBuf};
+
+use config::Config;
 
 const BUFFER_SIZE: usize = 32768 * 4;
 
@@ -44,6 +44,16 @@ pub struct ClientConfig {
 }
 
 impl ClientConfig {
+    fn new(log_file: String, address: String, port: String, id: String, dependencies: String) -> Self {
+        ClientConfig {
+            log_file,
+            address,
+            port,
+            id,
+            dependencies,
+        }
+    }
+
     pub fn get_log_file(&self) -> &str {
         &self.log_file
     }
@@ -71,55 +81,183 @@ const CONFIG_KEY_ADDR: &str = "address";
 const CONFIG_KEY_PORT: &str = "port";
 const CONFIG_KEY_LOG: &str = "log-file";
 
-pub fn load_config_file<P: AsRef<Path>>(images_dir: P) -> ClientConfig {
+pub fn load_config_file<P: AsRef<Path>>(images_dir: P, action: &str) -> ClientConfig {
     let images_dir = images_dir.as_ref();
-    let mut config_file = images_dir.join(Path::new(CONFIG_FILE));
-    if !config_file.is_file() {
-        // The following allows us to load global config files from /etc/criu.
-        // This is useful for example when we want to use the same config file
-        // for multiple containers.
-        let config_dir = PathBuf::from("/etc/criu");
-        config_file = config_dir.join(Path::new(CONFIG_FILE));
-        if !config_file.is_file() {
-            panic!("config file does not exist")
+    let local_config_file = images_dir.join(Path::new(CONFIG_FILE));
+
+    // Handle per-process configuration workflow
+    if local_config_file.is_file() {
+        // Example of per-process config file:
+        // {
+        //    "id": "A",
+        //    "dependencies": "B:C",
+        //    "address": "127.0.0.1",
+        //    "port": "8080",
+        //    "log-file": "/var/log/criu-coordinator.log"
+        // }
+        let settings = Config::builder().add_source(config::File::from(local_config_file)).build().unwrap();
+        let settings_map = settings.try_deserialize::<HashMap<String, String>>().unwrap();
+
+        return ClientConfig::new(
+            settings_map.get(CONFIG_KEY_LOG).cloned().unwrap_or_else(|| "-".to_string()),
+            settings_map.get(CONFIG_KEY_ADDR).cloned().unwrap_or_else(|| DEFAULT_ADDRESS.to_string()),
+            settings_map.get(CONFIG_KEY_PORT).cloned().unwrap_or_else(|| DEFAULT_PORT.to_string()),
+            settings_map.get(CONFIG_KEY_ID).unwrap().clone(),
+            settings_map.get(CONFIG_KEY_DEPS).cloned().unwrap_or_default(),
+        );
+    }
+
+    // The following allows us to load global config files from /etc/criu.
+    // This is useful for example when we want to use the same config file
+    // for multiple containers.
+    // Example of global config file:
+    // {
+    //    "address": "127.0.0.1",
+    //    "port": "8080",
+    //    "log-file": "/var/log/criu-coordinator.log",
+    //    "dependencies": {
+    //        "A": ["B", "C"],
+    //        "B": ["C", "A"],
+    //        "C": ["A"]
+    //    }
+    // }
+    // Where dependencies is a map of IDs (e.g: container IDs) to a list of dependencies.
+    let global_config_file = PathBuf::from("/etc/criu").join(Path::new(CONFIG_FILE));
+
+    if !global_config_file.is_file() {
+        panic!("Global config file {:?} is not found", global_config_file);
+    }
+
+    let global_settings = Config::builder().add_source(config::File::from(global_config_file)).build().unwrap();
+    let global_map = global_settings.try_deserialize::<HashMap<String, config::Value>>().unwrap();
+
+    let address = global_map.get(CONFIG_KEY_ADDR).map(|v| v.clone().into_string().unwrap()).unwrap_or_else(|| DEFAULT_ADDRESS.to_string());
+    let port = global_map.get(CONFIG_KEY_PORT).map(|v| v.clone().into_string().unwrap()).unwrap_or_else(|| DEFAULT_PORT.to_string());
+    let log_file = global_map.get(CONFIG_KEY_LOG).map(|v| v.clone().into_string().unwrap()).unwrap_or_else(|| "-".to_string());
+
+    if is_dump_action(action) {
+        let pid_str = env::var(ENV_INIT_PID)
+            .unwrap_or_else(|_| panic!("{} not set", ENV_INIT_PID));
+        let pid: u32 = pid_str.parse().expect("Invalid PID");
+
+
+        let deps_map: HashMap<String, Vec<String>> = global_map
+            .get(CONFIG_KEY_DEPS)
+            .unwrap_or_else(|| panic!("'{}' map is missing in global config", CONFIG_KEY_DEPS))
+            .clone().into_table().unwrap()
+            .into_iter().map(|(k, v)| {
+                let deps = v.into_array().unwrap().into_iter().map(|val| val.into_string().unwrap()).collect();
+                (k, deps)
+            }).collect();
+        
+        // We first try to find a container ID.
+        let id = match find_container_id_from_pid(pid) {
+            Ok(container_id) => container_id,
+            Err(_) => {
+                // If the PID is not in a container cgroup, we consider it a regular process.
+                // We identify it by its process name from /proc/<pid>/comm.
+                let process_name_path = format!("/proc/{pid}/comm");
+                if let Ok(name) = fs::read_to_string(process_name_path) {
+                    name.trim().to_string()
+                } else {
+                    // Fallback to using the PID as the ID if comm is unreadable
+                    pid.to_string()
+                }
+            }
+        };
+
+        let dependencies = find_dependencies_in_global_config(&deps_map, &id).unwrap();
+
+        // Write the local config for each container during dump
+        if action == ACTION_PRE_DUMP || action == ACTION_PRE_STREAM {
+            write_checkpoint_config(images_dir, &id, &dependencies);
+        }
+
+        ClientConfig::new(
+            log_file,
+            address,
+            port,
+            id,
+            dependencies,
+        )
+    } else { // Restore action
+        if !local_config_file.is_file() {
+            panic!("Restore action initiated, but no {CONFIG_FILE} found in the image directory {:?}", images_dir);
+        }
+
+        let local_settings = Config::builder().add_source(config::File::from(local_config_file)).build().unwrap();
+        let local_map = local_settings.try_deserialize::<HashMap<String, String>>().unwrap();
+
+        ClientConfig::new(
+            log_file,
+            address,
+            port,
+            local_map.get(CONFIG_KEY_ID).unwrap().clone(),
+            local_map.get(CONFIG_KEY_DEPS).cloned().unwrap_or_default(),
+        )
+    }
+}
+
+ /// Find containers dependencies by matching the discovered ID as a prefix of a key in the map
+fn find_dependencies_in_global_config(
+    deps_map: &HashMap<String, Vec<String>>,
+    id: &str,
+) -> Result<String, String> {
+    let deps = deps_map
+        .iter()
+        .find(|(key, _)| id.starts_with(*key))
+        .map(|(_, deps)| deps.join(":"))
+        .ok_or_else(|| {
+            format!("No dependency entry found for container ID matching '{id}'")
+        })?;
+    Ok(deps)
+}
+
+/// Find a container ID from the host PID by inspecting the process's cgroup.
+fn find_container_id_from_pid(pid: u32) -> Result<String, String> {
+    let cgroup_path = format!("/proc/{pid}/cgroup");
+    let cgroup_content = fs::read_to_string(&cgroup_path)
+        .map_err(|e| format!("Failed to read {cgroup_path}: {e}"))?;
+
+    let mut container_id: Option<String> = None;
+    for line in cgroup_content.lines() {
+        if line.len() < 64 {
+            continue;
+        }
+        for i in 0..=(line.len() - 64) {
+            let potential_id = &line[i..i + 64];
+            if potential_id.chars().all(|c| c.is_ascii_hexdigit()) {
+                let is_start = i == 0 || !line.chars().nth(i - 1).unwrap().is_ascii_hexdigit();
+                let is_end = (i + 64 == line.len())
+                    || !line.chars().nth(i + 64).unwrap().is_ascii_hexdigit();
+                if is_start && is_end {
+                    container_id = Some(potential_id.to_string());
+                }
+            }
         }
     }
 
-    let settings = Config::builder().add_source(config::File::from(config_file)).build().unwrap();
-    let settings_map = settings.try_deserialize::<HashMap<String, String>>().unwrap();
+    container_id.ok_or_else(|| {
+        format!("Could not find container ID from cgroup file for PID {pid}")
+    })
+}
 
-    if !settings_map.contains_key(CONFIG_KEY_ID) {
-        panic!("id missing in config file")
-    }
-    let id = settings_map.get(CONFIG_KEY_ID).unwrap();
+/// Write per-checkpoint configuration file into the checkpoint images directory.
+fn write_checkpoint_config(img_dir: &Path, id: &str, dependencies: &str) {
+    let config_path = img_dir.join(CONFIG_FILE);
+    let content = format!("{{\n   \"id\": \"{id}\",\n   \"dependencies\": \"{dependencies}\"\n}}",);
 
-    let mut dependencies = String::new();
-    if settings_map.contains_key(CONFIG_KEY_DEPS) {
-        dependencies = settings_map.get(CONFIG_KEY_DEPS).unwrap().to_string();
-    }
+    fs::write(&config_path, content)
+        .unwrap_or_else(|_| panic!("Failed to write checkpoint config file to {:?}", config_path))
+}
 
-    let mut address = DEFAULT_ADDRESS;
-    if settings_map.contains_key(CONFIG_KEY_ADDR) {
-        address = settings_map.get(CONFIG_KEY_ADDR).unwrap();
-    }
 
-    let mut port = DEFAULT_PORT;
-    if settings_map.contains_key(CONFIG_KEY_PORT) {
-        port = settings_map.get(CONFIG_KEY_PORT).unwrap();
-    }
+pub fn is_dump_action(action: &str) -> bool {
+    matches!(action, ACTION_PRE_DUMP | ACTION_NETWORK_LOCK | ACTION_POST_DUMP | ACTION_PRE_STREAM)
+}
 
-    let mut log_file = "-";
-    if settings_map.contains_key(CONFIG_KEY_LOG) {
-        log_file = settings_map.get(CONFIG_KEY_LOG).unwrap();
-    }
-
-    ClientConfig {
-        log_file: log_file.to_string(),
-        address: address.to_string(),
-        port: port.to_string(),
-        id: id.to_string(),
-        dependencies,
-    }
+pub fn is_restore_action(action: &str) -> bool {
+    matches!(action, ACTION_PRE_RESTORE | ACTION_POST_RESTORE | ACTION_NETWORK_UNLOCK | ACTION_POST_RESUME)
 }
 
 pub fn run_client(address: &str, port: u16, id: &str, deps: &str, action: &str, images_dir: &Path, enable_streaming: bool) {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -32,6 +32,8 @@ pub const ACTION_ADD_DEPENDENCIES: &str = "add-dependencies";
 pub const ENV_ACTION: &str = "CRTOOLS_SCRIPT_ACTION";
 /// ENV_IMAGE_DIR specifies path as used a base directory for CRIU images.
 pub const ENV_IMAGE_DIR: &str = "CRTOOLS_IMAGE_DIR";
+/// ENV_INIT_PID specifies the PID of the process to be checkpointed by CRIU.
+pub const ENV_INIT_PID: &str = "CRTOOLS_INIT_PID";
 
 /// Unix socket used for "criu dump".
 pub const IMG_STREAMER_CAPTURE_SOCKET_NAME: &str = "streamer-capture.sock";

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,84 +25,18 @@ mod pipeline;
 mod logger;
 
 use constants::*;
-use config::Config;
-use std::collections::HashMap;
 use std::{env, path::PathBuf, process::exit, fs, os::unix::prelude::FileTypeExt};
-use std::path::Path;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::{generate, Shell};
 use std::io;
 
-use cli::{Opts, Mode, DEFAULT_ADDRESS, DEFAULT_PORT};
+use cli::{Opts, Mode};
 use client::run_client;
 use server::run_server;
 use logger::init_logger;
 
-struct ClientConfig {
-    log_file: String,
-    address: String,
-    port: String,
-    id: String,
-    dependencies: String,
-}
-
-const CONFIG_KEY_ID: &str = "id";
-const CONFIG_KEY_DEPS: &str = "dependencies";
-const CONFIG_KEY_ADDR: &str = "address";
-const CONFIG_KEY_PORT: &str = "port";
-const CONFIG_KEY_LOG: &str = "log-file";
-
-fn load_config_file<P: AsRef<Path>>(images_dir: P) -> ClientConfig {
-    let images_dir = images_dir.as_ref();
-    let mut config_file = images_dir.join(Path::new(CONFIG_FILE));
-    if !config_file.is_file() {
-        // The following allows us to load global config files from /etc/criu.
-        // This is useful for example when we want to use the same config file
-        // for multiple containers.
-        let config_dir = PathBuf::from("/etc/criu");
-        config_file = config_dir.join(Path::new(CONFIG_FILE));
-        if !config_file.is_file() {
-            panic!("config file does not exist")
-        }
-    }
-
-    let settings = Config::builder().add_source(config::File::from(config_file)).build().unwrap();
-    let settings_map = settings.try_deserialize::<HashMap<String, String>>().unwrap();
-
-    if !settings_map.contains_key(CONFIG_KEY_ID) {
-        panic!("id missing in config file")
-    }
-    let id = settings_map.get(CONFIG_KEY_ID).unwrap();
-
-    let mut dependencies = String::new();
-    if settings_map.contains_key(CONFIG_KEY_DEPS) {
-        dependencies = settings_map.get(CONFIG_KEY_DEPS).unwrap().to_string();
-    }
-
-    let mut address = DEFAULT_ADDRESS;
-    if settings_map.contains_key(CONFIG_KEY_ADDR) {
-        address = settings_map.get(CONFIG_KEY_ADDR).unwrap();
-    }
-
-    let mut port = DEFAULT_PORT;
-    if settings_map.contains_key(CONFIG_KEY_PORT) {
-        port = settings_map.get(CONFIG_KEY_PORT).unwrap();
-    }
-
-    let mut log_file = "-";
-    if settings_map.contains_key(CONFIG_KEY_LOG) {
-        log_file = settings_map.get(CONFIG_KEY_LOG).unwrap();
-    }
-
-    ClientConfig {
-        log_file: log_file.to_string(),
-        address: address.to_string(),
-        port: port.to_string(),
-        id: id.to_string(),
-        dependencies,
-    }
-}
+use crate::client::load_config_file;
 
 fn main() {
     if let Ok(action) = env::var(ENV_ACTION) {
@@ -134,13 +68,13 @@ fn main() {
             _ => exit(0)
         };
 
-        init_logger(Some(&images_dir), client_config.log_file);
+        init_logger(Some(&images_dir), client_config.get_log_file().to_string());
 
         run_client(
-            &client_config.address,
-            client_config.port.parse().unwrap(),
-            &client_config.id,
-            &client_config.dependencies,
+            client_config.get_address(),
+            client_config.get_port().parse().unwrap(),
+            client_config.get_id(),
+            client_config.get_dependencies(),
             &action,
             &images_dir,
             enable_streaming

--- a/tests/e2e_criu.rs
+++ b/tests/e2e_criu.rs
@@ -145,6 +145,90 @@ fn setup(port: u16) -> Vec<TestProcess> {
     processes
 }
 
+fn setup_with_global_config(port: u16) -> Vec<TestProcess> {
+    println!("Setting up test environment with global config");
+
+    let make_status = Command::new("make")
+        .current_dir("tests")
+        .status()
+        .expect("Failed to run `make` in tests directory");
+    assert!(make_status.success(), "make command failed");
+
+    fs::create_dir_all("/etc/criu").expect("Failed to create /etc/criu directory");
+
+    // Create the global configuration file
+    let global_config_path = "/etc/criu/criu-coordinator.json";
+    let mut config_file =
+        fs::File::create(global_config_path).expect("Failed to create global config file");
+    let config_content = format!(
+        r#"{{
+            "address": "127.0.0.1",
+            "port": "{port}",
+            "log-file": "/tmp/criu-coordinator-global.log",
+            "dependencies": {{
+                "loop-1": ["loop-2", "loop-3"],
+                "loop-2": ["loop-1", "loop-3"],
+                "loop-3": ["loop-1", "loop-2"]
+            }}
+        }}"#
+    );
+
+    config_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to global config file");
+    println!("Created global config at {global_config_path}");
+
+    let mut processes = vec![];
+    let p_names = ["loop-1", "loop-2", "loop-3"];
+
+    for name in p_names.iter() {
+        let image_dir = env::temp_dir().join(format!(
+            "criu-e2e-test-global-{}-{}",
+            name,
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&image_dir);
+        fs::create_dir_all(&image_dir).expect("Failed to create image directory");
+
+        let dependencies: Vec<String> = p_names
+            .iter()
+            .filter(|&p| p != name)
+            .map(|&s| s.to_string())
+            .collect();
+
+        let mut command = Command::new(format!("./tests/{name}"));
+        command
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .stdin(Stdio::null());
+
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        let child = command
+            .spawn()
+            .unwrap_or_else(|_| panic!("Failed to spawn process {}", name));
+        let pid = child.id();
+
+        processes.push(TestProcess {
+            id: name.to_string(),
+            child: Some(child),
+            pid,
+            image_dir,
+            _dependencies: dependencies,
+        });
+        println!("Spawned '{name}' with PID {pid}");
+    }
+    thread::sleep(Duration::from_millis(500));
+    processes
+}
+
 fn cleanup(server: &mut Child, processes: &mut [TestProcess]) {
     println!("\n--- Cleaning up test environment ---");
     let _ = server.kill();
@@ -170,6 +254,13 @@ fn cleanup(server: &mut Child, processes: &mut [TestProcess]) {
             println!("Killed lingering process {} (PID: {})", p.id, pid);
         }
         let _ = fs::remove_dir_all(&p.image_dir);
+    }
+
+    // Clean up global config file and directory
+    let global_config_path = PathBuf::from("/etc/criu/criu-coordinator.json");
+    if global_config_path.exists() {
+        fs::remove_file(&global_config_path).expect("Failed to remove global config file");
+        println!("Removed global config file.");
     }
 
     let make_clean_status = Command::new("make")
@@ -307,6 +398,47 @@ fn setup_tcp_test(coordinator_port: u16, tcp_server_port: u16) -> Vec<TestProces
     processes
 }
 
+fn check_tcp_connection(server_pid: u32, client_pid: u32, server_port: u16) -> bool {
+    let output = match Command::new("ss").args(["-tpen"]).output() {
+        Ok(out) => out,
+        Err(e) => {
+            println!("Failed to execute 'ss' command: {e}. Is it installed?");
+            return false;
+        }
+    };
+
+    if !output.status.success() {
+        println!("'ss' command failed with status: {}", output.status);
+        return false;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let server_pid_str = format!("pid={server_pid}");
+    let client_pid_str = format!("pid={client_pid}");
+    let server_port_str = format!(":{server_port}");
+
+    // We expect to find two entries for the connections for each process.
+    let server_conn_found = stdout.lines().any(|line| {
+        line.contains("ESTAB") && line.contains(&server_port_str) && line.contains(&server_pid_str)
+    });
+
+    let client_conn_found = stdout.lines().any(|line| {
+        line.contains("ESTAB") && line.contains(&server_port_str) && line.contains(&client_pid_str)
+    });
+
+    if !server_conn_found || !client_conn_found {
+        println!("Could not verify established TCP connection via 'ss'.");
+        if !server_conn_found {
+            println!("Did not find connection for server PID {server_pid} on port {server_port}");
+        }
+        if !client_conn_found {
+            println!("Did not find connection for client PID {client_pid} to port {server_port}");
+        }
+    }
+
+    server_conn_found && client_conn_found
+}
+
 #[test]
 #[ignore] // requires require root privileges (make test-e2e)
 fn e2e_dump_and_restore_with_criu() {
@@ -317,7 +449,7 @@ fn e2e_dump_and_restore_with_criu() {
 
     assert!(is_criu_installed(), "CRIU command not found in PATH");
 
-    let coordinator_path = fs::canonicalize("target/debug/criu-coordinator")
+    let coordinator_path = fs::canonicalize(CRIU_COORDINATOR_PATH)
         .expect("Could not find criu-coordinator binary. Run 'cargo build' first.")
         .to_str()
         .unwrap()
@@ -418,48 +550,134 @@ fn e2e_dump_and_restore_with_criu() {
     }
 }
 
+#[test]
+#[ignore]
+fn e2e_dump_and_restore_with_global_config() {
+    assert!(
+        is_root(),
+        "This test must be run with root privileges for 'criu' and to write to /etc."
+    );
+    assert!(is_criu_installed(), "CRIU command not found in PATH");
 
-fn check_tcp_connection(server_pid: u32, client_pid: u32, server_port: u16) -> bool {
-    let output = match Command::new("ss").args(["-tpen"]).output() {
-        Ok(out) => out,
-        Err(e) => {
-            println!("Failed to execute 'ss' command: {e}. Is it installed?");
-            return false;
-        }
-    };
+    let coordinator_path = fs::canonicalize(CRIU_COORDINATOR_PATH)
+        .expect("Could not find criu-coordinator binary. Run 'cargo build' first.")
+        .to_str()
+        .unwrap()
+        .to_owned();
 
-    if !output.status.success() {
-        println!("'ss' command failed with status: {}", output.status);
-        return false;
+    let port = pick_port();
+    let addr = format!("127.0.0.1:{port}");
+    let server = spawn_server(port);
+    assert!(
+        server_ready(&addr, 20),
+        "Server failed to start at {}",
+        addr
+    );
+
+    let processes = setup_with_global_config(port);
+    let mut _guard = TestGuard { server, processes };
+
+    println!("\n--- Starting checkpoint phase (global config) ---");
+    let mut dump_handles = vec![];
+    for p in &_guard.processes {
+        let coordinator_path_clone = coordinator_path.clone();
+        let p_id = p.id.clone();
+        let p_pid = p.pid;
+        let p_image_dir = p.image_dir.clone();
+        dump_handles.push(thread::spawn(move || {
+            let out = Command::new("sudo")
+                .args([
+                    "criu",
+                    "dump",
+                    "-t",
+                    &p_pid.to_string(),
+                    "-D",
+                    p_image_dir.to_str().unwrap(),
+                    "-j",
+                    "-v4",
+                    "--action-script",
+                    &coordinator_path_clone,
+                ])
+                .output()
+                .expect("failed to execute criu");
+            (p_id, out)
+        }));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let server_pid_str = format!("pid={server_pid}");
-    let client_pid_str = format!("pid={client_pid}");
-    let server_port_str = format!(":{server_port}");
+    for handle in dump_handles {
+        let (id, output) = handle.join().unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success() && stderr.contains("Dumping finished successfully"),
+            "CRIU failed for process '{}' with global config.\nStderr:\n{}",
+            id,
+            stderr
+        );
+        println!("Checkpoint successful for {id}");
+    }
 
-    // We expect to find two entries for the connections for each process.
-    let server_conn_found = stdout.lines().any(|line| {
-        line.contains("ESTAB") && line.contains(&server_port_str) && line.contains(&server_pid_str)
-    });
-
-    let client_conn_found = stdout.lines().any(|line| {
-        line.contains("ESTAB") && line.contains(&server_port_str) && line.contains(&client_pid_str)
-    });
-
-    if !server_conn_found || !client_conn_found {
-        println!("Could not verify established TCP connection via 'ss'.");
-        if !server_conn_found {
-            println!("Did not find connection for server PID {server_pid} on port {server_port}");
-        }
-        if !client_conn_found {
-            println!("Did not find connection for client PID {client_pid} to port {server_port}");
+    println!("\n--- REAPING checkpointed processes (global config) ---");
+    for p in &mut _guard.processes {
+        if let Some(mut child) = p.child.take() {
+            match child.wait() {
+                Ok(status) => println!(
+                    "Reaped process {} (PID {}) with exit status: {}",
+                    p.id, p.pid, status
+                ),
+                Err(e) => eprintln!("Error reaping process {} (PID {}): {}", p.id, p.pid, e),
+            }
         }
     }
 
-    server_conn_found && client_conn_found
+    thread::sleep(Duration::from_millis(500));
+    println!("\n--- Starting restore phase (global config) ---");
+    let mut restore_handles = vec![];
+    for p in &_guard.processes {
+        let coordinator_path_clone = coordinator_path.clone();
+        let p_id = p.id.clone();
+        let p_image_dir = p.image_dir.clone();
+        restore_handles.push(thread::spawn(move || {
+            let out = Command::new("sudo")
+                .args([
+                    "criu",
+                    "restore",
+                    "-D",
+                    p_image_dir.to_str().unwrap(),
+                    "-d",
+                    "-v4",
+                    "--action-script",
+                    &coordinator_path_clone,
+                ])
+                .output()
+                .expect("failed to execute criu restore");
+            (p_id, out)
+        }));
+    }
+
+    for handle in restore_handles {
+        let (id, output) = handle.join().unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success() && stderr.contains("Restore finished successfully"),
+            "CRIU restore failed for process '{}' with global config.\nStderr:\n{}",
+            id,
+            stderr
+        );
+        println!("Restore successful for {id}");
+    }
+
+    thread::sleep(Duration::from_millis(500));
+
+    println!("\n--- VERIFYING restored processes (global config) ---");
+    for p in &_guard.processes {
+        assert!(
+            get_pid_by_name(&p.id).is_some(),
+            "Process {} was not found running after restore.",
+            p.id
+        );
+        println!("Verified process {} is running.", p.id);
+    }
 }
-
 
 #[test]
 #[ignore] // requires require root privileges (make test-e2e)


### PR DESCRIPTION
This PR adds support for global configuration file. Before, users had to create a separate configuration file for each process involved in the coordinated checkpoint. This PR enables the usage of a single config file for multiple processes. The global config should be stored inside `/etc/criu/criu-coordinator.json` and it uses a slightly different format from the per-process config.

Example of global config:
```json
    {
       "address": "127.0.0.1",
       "port": "8080",
       "log-file": "/var/log/criu-coordinator.log",
       "dependencies": {
           "A": ["B", "C"],
           "B": ["C", "A"],
           "C": ["A"]
       }
    }
```